### PR TITLE
Fix docs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ which implements `:http-xhrio`.
 The supplied value should be an options map as defined by the simple interface `ajax-request` [see: api docs](https://github.com/JulianBirch/cljs-ajax#ajax-request). Except for `:on-success` and `:on-failure`. All options supported by `ajax-request`
 should be supported by this library, as it is a thin wrapper over `ajax-request`.
 
-Here is an example of a POST request. Note that `:request-format` also needs to be specified.
+Here is an example of a POST request. Note that `:format` also needs to be specified.
 
 ```cljs
 (re-frame/reg-event-fx
@@ -87,7 +87,7 @@ You can also pass a list or vector of these options maps where multiple HTTPs ar
 
 ### Step 3. Handlers for :on-success and :on-failure
 
-Provide normal re-frame handlers for :on-success and :on-failure. Your event
+Provide normal re-frame handlers for `:on-success` and `:on-failure`. Your event
 handlers will get the result as the last arg of their event-v. Here is an
 example written as another effect handler to put the result into db.
 

--- a/src/day8/re_frame/http_fx.cljs
+++ b/src/day8/re_frame/http_fx.cljs
@@ -14,7 +14,7 @@
 ;; :on-success    - event vector dispatched with result
 ;; :on-failure    - event vector dispatched with result
 ;;
-;; NOTE: if you nee tokens or other values for your handlers,
+;; NOTE: if you need tokens or other values for your handlers,
 ;;       provide them in the on-success and on-failure event e.g.
 ;;       [:success-event "my-token"] your handler will get event-v
 ;;       [:success-event "my-token" result]

--- a/src/day8/re_frame/http_fx.cljs
+++ b/src/day8/re_frame/http_fx.cljs
@@ -43,14 +43,14 @@
            on-failure      [:http-no-on-failure]}}]
   ; wrap events in cljs-ajax callback
   (let [api (new js/goog.net.XhrIo)]
-  (-> request
-      (assoc
-        :api     api
-        :handler (partial ajax-xhrio-handler
-                          #(dispatch (conj on-success %))
-                          #(dispatch (conj on-failure %))
-                          api))
-      (dissoc :on-success :on-failure))))
+    (-> request
+        (assoc
+          :api     api
+          :handler (partial ajax-xhrio-handler
+                            #(dispatch (conj on-success %))
+                            #(dispatch (conj on-failure %))
+                            api))
+        (dissoc :on-success :on-failure))))
 
 ;; Specs commented out until ClojureScript has a stable release of spec.
 ;


### PR DESCRIPTION
This fixes a small typo in the documentation for POST example.

I also saw an unindented `let` body and fixed that, but I can revert if you'd rather not have whitespace changes.

Thanks for this library, it's great! 👏 