### PR TITLE
Change npm dependencies to devDependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,10 +38,10 @@
                   ["vcs" "commit"]
                   ["vcs" "push"]]
 
-  :npm {:dependencies [[karma                 "1.0.0"]
-                       [karma-cljs-test       "0.1.0"]
-                       [karma-chrome-launcher "0.2.0"]
-                       [karma-junit-reporter  "0.3.8"]]}
+  :npm {:devDependencies [[karma                 "1.0.0"]
+                          [karma-cljs-test       "0.1.0"]
+                          [karma-chrome-launcher "0.2.0"]
+                          [karma-junit-reporter  "0.3.8"]]}
 
   :cljsbuild {:builds [{:id           "test"
                         :source-paths ["test" "src"]


### PR DESCRIPTION
These NPM dependencies are getting pulled in with lein-npm for projects that use re-frame-http-fx and lein-npm, but they should be marked as devDependencies just like the change in re-frame itself (https://github.com/Day8/re-frame/commit/79a1ea6851382f9c113271addaf63e11155d5aa0).