### PR TITLE
Don't require cljs-ajax' API wholesale

### DIFF
--- a/src/day8/re_frame/http_fx.cljs
+++ b/src/day8/re_frame/http_fx.cljs
@@ -2,7 +2,8 @@
   (:require
     [goog.net.ErrorCode :as errors]
     [re-frame.core :refer [reg-fx dispatch console]]
-    [ajax.core :as ajax]
+    [ajax.simple :as ajax]
+    [ajax.xhrio]
     #_[cljs.spec :as s]))
 
 ;; I provide the :http-xhrio effect handler leveraging cljs-ajax lib


### PR DESCRIPTION
# About this PR

This PR changes the `day8.re-frame.http-fx` ns definition to only require the namespaces within cljs-ajax that are essential to the fx, rather than the whole API. It doesn't impact functionality in any way.

# Why?

Short answer: to avoid pulling in `cognitect.transit`.

Longer answer: cljs-ajax's formats include `transit-request-format` and `transit-response-format`, to facilitate efficient sending of Clojure/Script data structures over the wire. That's all well and good, but consumers of re-frame-http-fx may not need it.

Now, Closure Compiler is normally quite efficient in optimizing it away if it's not needed. However, a complication might arise when some other part of the code _does_ need it, and ClojureScript's [code splitting](https://clojurescript.org/guides/code-splitting) facility is in use.

Consider this scenario:
- Module A uses `re-frame-http-fx`, but never uses the `transit-*-format`s
- Module B depends on A, and uses transit for something else altogether

Without this PR, `transit` will be compiled into A even though it's never used when B is not loaded. With it, the compiler is able to lift `transit` out of A and into B.

This is exactly what we do at [WorksHub](https://www.works-hub.com). In our case, enabling this change causes our main JS code (advanced optimizations, uncompressed) to weigh 25 KiB less.