### PR TITLE
Allow api xhrio obj to be provided as test mocks

### DIFF
--- a/src/day8/re_frame/http_fx.cljs
+++ b/src/day8/re_frame/http_fx.cljs
@@ -44,7 +44,7 @@
     :or   {on-success      [:http-no-on-success]
            on-failure      [:http-no-on-failure]}}]
   ; wrap events in cljs-ajax callback
-  (let [api (new goog.net.XhrIo)]
+  (let [api (or (:api request) (new goog.net.XhrIo))]
     (-> request
         (assoc
           :api     api


### PR DESCRIPTION
When writing tests, I would like to be able to provide a mock implementation of the xhrio object.